### PR TITLE
Add direct API solve test

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -229,4 +229,115 @@ const Lib = cuPDLPx.LibcuPDLPx
         rm(mps_path) # delete temp file
     end
 
+    # ==========================================
+    # 7. Integration Test: Direct Matrix Construction
+    # ==========================================
+    @testset "Direct API Solve" begin
+        println("\n   > Starting Direct API Solve Test...")
+
+        # -------------------------------------------------------
+        # Problem Data Definition
+        #  maximize
+        #        x +   y + 2 z
+        #  subject to
+        #        x + 2 y + 3 z <= 4
+        #        x +   y       >= 1
+        #        0 <= x, y, z <= 1
+        # -------------------------------------------------------
+        n_vars = 3
+        m_cons = 2
+
+        # 1. Objective Vector (Minimize direction)
+        c = Cdouble[-1.0, -1.0, -2.0]
+        obj_const = Cdouble[0.0] # Must be a pointer
+
+        # 2. Variable Bounds (Relax Binary -> [0, 1])
+        var_lb = Cdouble[0.0, 0.0, 0.0]
+        var_ub = Cdouble[1.0, 1.0, 1.0]
+
+        # 3. Constraint Matrix Data (CSR Format)
+        # Row 0:  1.0,  2.0, 3.0  (indices 0, 1, 2)
+        # Row 1: -1.0, -1.0       (indices 0, 1)
+        csr_vals    = Cdouble[1.0, 2.0, 3.0, -1.0, -1.0]
+        csr_col_ind = Cint[0, 1, 2, 0, 1]
+        csr_row_ptr = Cint[0, 3, 5]
+        nnz = Cint(5)
+
+        # 4. Constraint Bounds
+        # Row 0: ... <= 4.0  -> (-Inf, 4.0]
+        # Row 1: ... <= -1.0 -> (-Inf, -1.0]
+        con_lb = Cdouble[-Inf, -Inf]
+        con_ub = Cdouble[4.0, -1.0]
+
+        # -------------------------------------------------------
+        # C Struct Construction
+        # -------------------------------------------------------
+        
+        # A. Construct MatrixCSR
+        A_csr = Lib.MatrixCSR(
+            nnz,
+            pointer(csr_row_ptr),
+            pointer(csr_col_ind),
+            pointer(csr_vals)
+        )
+
+        # B. Construct matrix_desc_t        
+        # 1. Allocate zeroed struct on Julia side
+        A_desc_ref = Ref{Lib.matrix_desc_t}()
+        A_desc_ref[] = Lib.matrix_desc_t(ntuple(_ -> UInt8(0), 56)) # Clear memory
+        A_desc_ptr = Base.unsafe_convert(Ptr{Lib.matrix_desc_t}, A_desc_ref)
+
+        # 2. Set Scalar Fields
+        A_desc_ptr.m = Cint(m_cons)
+        A_desc_ptr.n = Cint(n_vars)
+        A_desc_ptr.fmt = Lib.matrix_csr
+        A_desc_ptr.zero_tolerance = 0.0
+
+        # 3. Set The Union Data
+        A_desc_ptr.data.csr = A_csr
+
+        # -------------------------------------------------------
+        # Create and Solve
+        # -------------------------------------------------------
+        
+        # Create LP Problem
+        prob = Lib.create_lp_problem(
+            pointer(c),
+            A_desc_ptr,
+            pointer(con_lb),
+            pointer(con_ub),
+            pointer(var_lb),
+            pointer(var_ub),
+            pointer(obj_const)
+        )
+        @test prob != C_NULL
+
+        # Setup Parameters
+        params_ref = Ref{Lib.pdhg_parameters_t}()
+        params_ptr = Base.unsafe_convert(Ptr{Lib.pdhg_parameters_t}, params_ref)
+        Lib.set_default_parameters(params_ptr)
+
+        # Solve
+        result_ptr = Lib.solve_lp_problem(prob, params_ptr)
+        @test result_ptr != C_NULL
+        
+        result = unsafe_load(result_ptr)
+
+        # -------------------------------------------------------
+        # Validation
+        # -------------------------------------------------------
+        println("   > Direct Solve Status: $(result.termination_reason)")
+        println("   > Direct Solve Obj: $(result.primal_objective_value)")
+
+        # Optimal happens at x=1, y=0, z=1 => Obj = 3.
+        # Since we minimized negative: Target = -3.0
+        @test result.termination_reason == Lib.TERMINATION_REASON_OPTIMAL
+        @test isapprox(result.primal_objective_value, -3.0, atol=1e-4)
+
+        # Cleanup
+        Lib.cupdlpx_result_free(result_ptr)
+        Lib.lp_problem_free(prob)
+        println("   > Direct API Solve test passed.")
+    end
+
 end


### PR DESCRIPTION
### Description
This PR adds a new test case that solves an LP using vectors and matrix data directly.

**Output**
```bash
(cuPDLPx) pkg> test
     Testing cuPDLPx
      Status `/orcd/home/002/zdpeng/tmp/jl_4pee5G/Project.toml`
  [40e3b903] Clang v0.19.0
  [b8f27783] MathOptInterface v1.46.0
  [bcd6524d] cuPDLPx v0.1.4 `/orcd/home/002/zdpeng/github/cuPDLPx.jl`
  [76a88914] CUDA_Runtime_jll v0.19.2+0
  [6cbf2f2e] CUDA_SDK_jll v13.0.2+1
  [bca5daad] cuPDLPx_jll v0.1.4+0
  [8dfed614] Test v1.11.0
      Status `/orcd/home/002/zdpeng/tmp/jl_4pee5G/Manifest.toml`
  [6e4b80f9] BenchmarkTools v1.6.3
  [fa961155] CEnum v0.5.0
  [40e3b903] Clang v0.19.0
  [523fee87] CodecBzip2 v0.8.5
  [944b1d66] CodecZlib v0.7.8
  [bbf7d656] CommonSubexpressions v0.3.1
  [34da2185] Compat v4.18.1
  [864edb3b] DataStructures v0.19.3
  [163ba53b] DiffResults v1.1.0
  [b552c78f] DiffRules v1.15.1
  [ffbed154] DocStringExtensions v0.9.5
  [f6369f11] ForwardDiff v1.3.0
  [92d709cd] IrrationalConstants v0.2.6
  [692b3bcd] JLLWrappers v1.7.1
  [682c06a0] JSON v1.3.0
  [0f8b85d8] JSON3 v1.14.3
  [2ab3a3ac] LogExpFunctions v0.3.29
  [1914dd2f] MacroTools v0.5.16
  [b8f27783] MathOptInterface v1.46.0
  [d8a4904e] MutableArithmetics v1.6.7
  [77ba4419] NaNMath v1.1.3
  [bac558e1] OrderedCollections v1.8.1
  [69de0a69] Parsers v2.8.3
⌅ [aea7be01] PrecompileTools v1.2.1
  [21216c6a] Preferences v1.5.0
  [276daf66] SpecialFunctions v2.6.1
  [1e83bf80] StaticArraysCore v1.4.4
  [10745b16] Statistics v1.11.1
  [856f2bd8] StructTypes v1.11.0
  [ec057cc2] StructUtils v2.6.0
  [3bb67fe8] TranscodingStreams v0.11.3
  [bcd6524d] cuPDLPx v0.1.4 `/orcd/home/002/zdpeng/github/cuPDLPx.jl`
  [6e34b625] Bzip2_jll v1.0.9+0
  [4ee394cb] CUDA_Driver_jll v13.0.2+0
  [76a88914] CUDA_Runtime_jll v0.19.2+0
  [6cbf2f2e] CUDA_SDK_jll v13.0.2+1
⌅ [0ee61d77] Clang_jll v16.0.6+5
  [efe28fd5] OpenSpecFun_jll v0.5.6+0
  [bca5daad] cuPDLPx_jll v0.1.4+0
  [0dad84c5] ArgTools v1.1.2
  [56f22d72] Artifacts v1.11.0
  [2a0f44e3] Base64 v1.11.0
  [ade2ca70] Dates v1.11.0
  [f43a241f] Downloads v1.6.0
  [7b1f6079] FileWatching v1.11.0
  [b77e0a4c] InteractiveUtils v1.11.0
  [4af54fe1] LazyArtifacts v1.11.0
  [b27032c2] LibCURL v0.6.4
  [76f85450] LibGit2 v1.11.0
  [8f399da3] Libdl v1.11.0
  [37e2e46d] LinearAlgebra v1.11.0
  [56ddb016] Logging v1.11.0
  [d6f4376e] Markdown v1.11.0
  [a63ad114] Mmap v1.11.0
  [ca575930] NetworkOptions v1.2.0
  [44cfe95a] Pkg v1.11.0
  [de0858da] Printf v1.11.0
  [9abbd945] Profile v1.11.0
  [9a3f8284] Random v1.11.0
  [ea8e919c] SHA v0.7.0
  [9e88b42a] Serialization v1.11.0
  [2f01184e] SparseArrays v1.11.0
  [fa267f1f] TOML v1.0.3
  [a4e569a6] Tar v1.10.0
  [8dfed614] Test v1.11.0
  [cf7118a7] UUIDs v1.11.0
  [4ec0a83e] Unicode v1.11.0
  [e66e0078] CompilerSupportLibraries_jll v1.1.1+0
  [deac9b47] LibCURL_jll v8.6.0+0
  [e37daf67] LibGit2_jll v1.7.2+0
  [29816b5a] LibSSH2_jll v1.11.0+1
  [c8ffd9c3] MbedTLS_jll v2.28.6+0
  [14a3606d] MozillaCACerts_jll v2023.12.12
  [4536629a] OpenBLAS_jll v0.3.27+1
  [05823500] OpenLibm_jll v0.8.5+0
  [bea87d4a] SuiteSparse_jll v7.7.0+0
  [83775a58] Zlib_jll v1.2.13+1
  [8f36deef] libLLVM_jll v16.0.6+5
  [8e850b90] libblastrampoline_jll v5.11.0+0
  [8e850ede] nghttp2_jll v1.59.0+0
  [3f19e933] p7zip_jll v17.4.0+2
        Info Packages marked with ⌅ have new versions available but compatibility constraints restrict them from upgrading.
     Testing Running tests...
   > MatrixData Union logic verified (Address offsets are correct).
   > Successfully called set_default_parameters from C library.
   > Defaults loaded check: Time Limit = 3600.0
   > Created temp MPS file at: /home/zdpeng/tmp/afiro.mps
   > Loaded Problem: 32 vars, 27 cons
Solution Summary
  Status        : OPTIMAL
  Iterations    : 450
  Solve time    : 0.0167 sec
  Primal obj    : -464.7521019
  Dual obj      : -464.8091672
  Primal infeas : 9.790e-06
  Dual infeas   : 8.405e-06
   > MPS Solve Status: TERMINATION_REASON_OPTIMAL
   > MPS Primal Obj: -464.75210194355793

   > Starting Direct API Solve Test...
Solution Summary
  Status        : OPTIMAL
  Iterations    : 210
  Solve time    : 0.00708 sec
  Primal obj    : -3
  Dual obj      : -3
  Primal infeas : 0.000e+00
  Dual infeas   : 7.383e-17
   > Direct Solve Status: TERMINATION_REASON_OPTIMAL
   > Direct Solve Obj: -3.0
   > Direct API Solve test passed.
Test Summary:                | Pass  Total  Time
LibcuPDLPx Translation Tests |   25     25  1.1s
     Testing cuPDLPx tests passed 
```