### PR TITLE
Rename cuPDLPx to CuPDLPx

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.12.2"
 manifest_format = "2.0"
-project_hash = "54309def7c908068951b3458be89fae48b84f475"
+project_hash = "bafeb480db5d158cbd64df5b52603b3abbbce294"
 
 [[deps.ArgTools]]
 uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
@@ -95,6 +95,12 @@ weakdeps = ["Dates", "LinearAlgebra"]
 deps = ["Artifacts", "Libdl"]
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
 version = "1.3.0+1"
+
+[[deps.CuPDLPx]]
+deps = ["CUDA_Runtime_jll", "CUDA_SDK_jll", "Clang", "MathOptInterface", "Test", "cuPDLPx_jll"]
+path = "."
+uuid = "bcd6524d-1420-4b17-a582-359cb8a71a63"
+version = "0.2.3"
 
 [[deps.Dates]]
 deps = ["Printf"]
@@ -455,12 +461,6 @@ version = "1.11.0"
 deps = ["Libdl"]
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
 version = "1.3.1+2"
-
-[[deps.cuPDLPx]]
-deps = ["CUDA_Runtime_jll", "CUDA_SDK_jll", "Clang", "MathOptInterface", "Test", "cuPDLPx_jll"]
-path = "."
-uuid = "bcd6524d-1420-4b17-a582-359cb8a71a63"
-version = "0.2.2"
 
 [[deps.cuPDLPx_jll]]
 deps = ["Artifacts", "CUDA_Runtime_jll", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "TOML", "Zlib_jll"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,4 +1,4 @@
-name = "cuPDLPx"
+name = "CuPDLPx"
 uuid = "bcd6524d-1420-4b17-a582-359cb8a71a63"
 version = "0.2.3"
 

--- a/README.md
+++ b/README.md
@@ -1,35 +1,35 @@
-# cuPDLPx.jl
-Julia interface for cuPDLPx.
+# CuPDLPx.jl
+Julia interface for [cuPDLPx](https://github.com/MIT-Lu-Lab/cuPDLPx).
 
 ## Installation
-cuPDLPx.jl is available from the Julia General registry:
+CuPDLPx.jl is available from the Julia General registry:
 
 ```julia
-pkg> add cuPDLPx
+pkg> add CuPDLPx
 ```
 
 ## Use with JuMP
 
-To use cuPDLPx with JuMP, use `cuPDLPx.Optimizer`:
+To use CuPDLPx with JuMP, use `CuPDLPx.Optimizer`:
 
 ```julia
-using JuMP, cuPDLPx
-model = Model(cuPDLPx.Optimizer)
+using JuMP, CuPDLPx
+model = Model(CuPDLPx.Optimizer)
 ```
 
 ## Setting solver parameters
 
-cuPDLPx.jl supports setting solver parameters via `set_optimizer_attribute`.
+CuPDLPx.jl supports setting solver parameters via `set_optimizer_attribute`.
 
 ```Julia
 using JuMP
-using cuPDLPx
+using CuPDLPx
 
 model = read_from_file("2club200v15p5scn.mps.gz")
 undo = relax_integrality(model)
 
 println("Read MPS succeed.")
-set_optimizer(model, cuPDLPx.Optimizer)
+set_optimizer(model, CuPDLPx.Optimizer)
 
 set_optimizer_attribute(model, "verbose", true)
 set_optimizer_attribute(model, "l_inf_ruiz_iterations", 0)

--- a/gen/generate.jl
+++ b/gen/generate.jl
@@ -19,9 +19,9 @@ ctx = create_context(headers, args, options)
 
 ctx.options["is_function_allowed"] = (cursor, spelling) -> startswith(spelling, "cupdlpx_")
 
-output_file = joinpath(@__DIR__, "src", "LibcuPDLPx.jl")
+output_file = joinpath(@__DIR__, "src", "LibCuPDLPx.jl")
 mkpath(dirname(output_file))
 
 build!(ctx)
 
-println("✅ Successfully generated LibcuPDLPx.jl at $(output_file)")
+println("✅ Successfully generated LibCuPDLPx.jl at $(output_file)")

--- a/gen/generate.toml
+++ b/gen/generate.toml
@@ -1,7 +1,7 @@
 [general]
 library_name = "libcupdlpx"
-output_file_path = "./src/LibcuPDLPx.jl"
-module_name = "LibcuPDLPx"
+output_file_path = "./src/LibCuPDLPx.jl"
+module_name = "LibCuPDLPx"
 jll_pkg_name = "cuPDLPx_jll"
 use_julia_native_enum_type = true
 extract_c_comment_style = "doxygen"

--- a/src/CuPDLPx.jl
+++ b/src/CuPDLPx.jl
@@ -1,0 +1,7 @@
+module CuPDLPx
+
+# using Base.Enums
+include("LibCuPDLPx.jl")
+include("MOI_wrapper.jl")
+
+end # module CuPDLPx

--- a/src/LibCuPDLPx.jl
+++ b/src/LibCuPDLPx.jl
@@ -1,4 +1,4 @@
-module LibcuPDLPx
+module LibCuPDLPx
 
 using cuPDLPx_jll
 export cuPDLPx_jll

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -1,6 +1,6 @@
 import MathOptInterface as MOI
 
-const Lib = cuPDLPx.LibcuPDLPx
+const Lib = CuPDLPx.LibCuPDLPx
 
 MOI.Utilities.@product_of_sets(
     _LPProductOfSets,
@@ -26,7 +26,7 @@ const OptimizerCache = MOI.Utilities.GenericModel{
     },
 }
 
-Base.show(io::IO, ::Type{OptimizerCache}) = print(io, "cuPDLPx.OptimizerCache")
+Base.show(io::IO, ::Type{OptimizerCache}) = print(io, "CuPDLPx.OptimizerCache")
 
 const BOUND_SETS = Union{
     MOI.GreaterThan{Float64},
@@ -137,7 +137,7 @@ end
 #   Parameters
 # ====================
 
-MOI.get(::Optimizer, ::MOI.SolverName) = "cuPDLPx"
+MOI.get(::Optimizer, ::MOI.SolverName) = "CuPDLPx"
 
 function MOI.supports(::Optimizer, param::MOI.RawOptimizerAttribute)
     s = Symbol(param.name)

--- a/src/cuPDLPx.jl
+++ b/src/cuPDLPx.jl
@@ -1,7 +1,0 @@
-module cuPDLPx
-
-# using Base.Enums
-include("LibcuPDLPx.jl")
-include("MOI_wrapper.jl")
-
-end # module cuPDLPx

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -2,10 +2,10 @@ module TestMOI
 
 using Test
 import MathOptInterface as MOI
-import cuPDLPx
+import CuPDLPx
 
 function test_runtests()
-    optimizer = cuPDLPx.Optimizer()
+    optimizer = CuPDLPx.Optimizer()
     MOI.set(optimizer, MOI.Silent(), true) # comment this to enable output
     model = MOI.Bridges.full_bridge_optimizer(
         MOI.Utilities.CachingOptimizer(

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,9 @@
 using Test
-using cuPDLPx
+using CuPDLPx
 
-const Lib = cuPDLPx.LibcuPDLPx
+const Lib = CuPDLPx.LibCuPDLPx
 
-@testset "LibcuPDLPx Translation Tests" begin
+@testset "LibCuPDLPx Translation Tests" begin
 
     # ==========================================
     # 1. Basic Enum Mapping Tests


### PR DESCRIPTION
### Summary
This PR renames cuPDLPx to CuPDLPx to obey Julia's [Package naming rule](https://pkgdocs.julialang.org/v1/creating-packages/#Package-naming-rules).

Related issue: https://github.com/JuliaRegistries/General/pull/146726