### PR TITLE
Add support for reduced cost

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -458,6 +458,15 @@ function MOI.get(
     return unsafe_load(optimizer.result.dual_solution, row)
 end
 
+function MOI.get(
+    optimizer::Optimizer, 
+    attr::MOI.ConstraintDual, 
+    ci::MOI.ConstraintIndex{MOI.VariableIndex,S}, 
+) where {S<:MOI.AbstractSet}
+    MOI.check_result_index_bounds(optimizer, attr)
+    return unsafe_load(optimizer.result.reduced_cost, ci.value)
+end
+
 function MOI.get(optimizer::Optimizer, ::MOI.ResultCount)
     return isnothing(optimizer.result) ? 0 : 1
 end

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -459,12 +459,36 @@ function MOI.get(
 end
 
 function MOI.get(
-    optimizer::Optimizer, 
-    attr::MOI.ConstraintDual, 
-    ci::MOI.ConstraintIndex{MOI.VariableIndex,S}, 
-) where {S<:MOI.AbstractSet}
+    optimizer::Optimizer,
+    attr::MOI.ConstraintDual,
+    ci::MOI.ConstraintIndex{MOI.VariableIndex,MOI.LessThan{Float64}},
+)
     MOI.check_result_index_bounds(optimizer, attr)
-    return unsafe_load(optimizer.result.reduced_cost, ci.value)
+    rc = unsafe_load(optimizer.result.reduced_cost, ci.value)
+    return min(0.0, rc)
+end
+
+function MOI.get(
+    optimizer::Optimizer,
+    attr::MOI.ConstraintDual,
+    ci::MOI.ConstraintIndex{MOI.VariableIndex,MOI.GreaterThan{Float64}},
+)
+    MOI.check_result_index_bounds(optimizer, attr)
+    rc = unsafe_load(optimizer.result.reduced_cost, ci.value)
+    return max(0.0, rc)
+end
+
+function MOI.get(
+    optimizer::Optimizer,
+    attr::MOI.ConstraintDual,
+    ci::MOI.ConstraintIndex{
+        MOI.VariableIndex,
+        <:Union{MOI.Interval{Float64},MOI.EqualTo{Float64}},
+    },
+)
+    MOI.check_result_index_bounds(optimizer, attr)
+    rc = unsafe_load(optimizer.result.reduced_cost, ci.value)
+    return rc
 end
 
 function MOI.get(optimizer::Optimizer, ::MOI.ResultCount)

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -30,7 +30,7 @@ function test_runtests()
         model,
         config,
         # failed tests
-        # some implementations not supported yet, such as reduced costs, TimeLimitSec, etc.
+        # some implementations not supported yet, such as TimeLimitSec, etc.
         exclude = [r"^test_infeasible_MAX_SENSE$",
                    r"^test_infeasible_MAX_SENSE_offset$",
                    r"^test_infeasible_MIN_SENSE$",
@@ -50,10 +50,6 @@ function test_runtests()
                    r"^test_solve_DualStatus_INFEASIBILITY_CERTIFICATE_LessThan$",
                    r"^test_solve_DualStatus_INFEASIBILITY_CERTIFICATE_VariableIndex_LessThan$",
                    r"^test_solve_DualStatus_INFEASIBILITY_CERTIFICATE_VariableIndex_LessThan_max$",
-                   r"^test_solve_VariableIndex_ConstraintDual_MAX_SENSE$",
-                   r"^test_solve_VariableIndex_ConstraintDual_MIN_SENSE$",
-                   r"^test_variable_solve_with_lowerbound$",
-                   r"^test_variable_solve_with_upperbound$",
                   ],
         verbose = true,
     )


### PR DESCRIPTION
### Fixes #17 
### Summary
This PR adds support for reduced cost.

### Current Issue
The current wrapper fails `test_solve_VariableIndex_ConstraintDual_MAX_SENSE` because cuPDLPx uses a boxed-bounds representation, so `xl` and `xu` can map to the same internal index.

### Question
- Should we branch on the set type (`GreaterThan`, `LessThan`, `EqualTo`, `Interval`) when returning `ConstraintDual` for `VariableIndex` constraints? 
- One more question. Does it also apply to `ConstraintDual` for `MOI.ScalarAffineFunction`?

@blegat @odow 

Test code
```julia
import MathOptInterface as MOI
using CuPDLPx

T = Float64
import MathOptInterface.Utilities as MOIU


model = MOI.instantiate(CuPDLPx.Optimizer; with_cache_type = T)

x  = MOI.add_variable(model)
xl = MOI.add_constraint(model, x, MOI.GreaterThan(T(1)))
xu = MOI.add_constraint(model, x, MOI.LessThan(T(1)))

MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
MOI.set(model, MOI.ObjectiveFunction{MOI.VariableIndex}(), x)
MOI.set(model, MOI.RawOptimizerAttribute("verbose"), true)

MOI.optimize!(model)

sl = MOI.get(model, MOI.ConstraintDual(), xl)
su = MOI.get(model, MOI.ConstraintDual(), xu)

@show sl su sl+su
```

Output
```
---------------------------------------------------------------------------------------
                                    cuPDLPx v0.2.5                                    
                        A GPU-Accelerated First-Order LP Solver                        
               (c) Haihao Lu, Massachusetts Institute of Technology, 2025              
---------------------------------------------------------------------------------------
problem: 0 rows, 1 columns, 0 nonzeros
settings:
  iter_limit         : 2147483647
  time_limit         : 3600.00 sec
  eps_opt            : 1.0e-04
  eps_feas           : 1.0e-04

Running presolver (PSLP v0.0.4)...
  status          : REDUCED
  presolve time   : 0.000205 sec
  reduced problem : 0 rows, 0 columns, 0 nonzeros
---------------------------------------------------------------------------------------
Solution Summary
  Status                 : OPTIMAL
  Presolve time          : 0.000205 sec
  Precondition time      : 0 sec
  Solve time             : 0 sec
  Iterations             : 0
  Primal objective       : -1
  Dual objective         : -1
  Objective gap          : 0.000e+00
  Primal infeas          : 0.000e+00
  Dual infeas            : 0.000e+00

ci.value = 1
ci.value = 1
sl = -1.0
su = -1.0
sl + su = -2.0
-2.0
```
