### PR TITLE
Drop unused CUDA JLL deps for CUDA.jl v6 support, bump to v0.2.8

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,8 +1,8 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.12.2"
+julia_version = "1.12.5"
 manifest_format = "2.0"
-project_hash = "ff6a90e46a33ffd0fa8bfe6de7d3bd2954e73933"
+project_hash = "6dc1371b3d2cac484ed1625f4263cad15cca1fe9"
 
 [[deps.ArgTools]]
 uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
@@ -40,12 +40,6 @@ git-tree-sha1 = "92cd84e2b760e471d647153ea5efc5789fc5e8b2"
 uuid = "76a88914-d11a-5bdc-97e0-2f5a05c973a2"
 version = "0.19.2+0"
 
-[[deps.CUDA_SDK_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "c1fd6fe1a1a198afa28b425737f6afffe667096e"
-uuid = "6cbf2f2e-7e60-5632-ac76-dca2274e0be0"
-version = "13.2.0+0"
-
 [[deps.CodecBzip2]]
 deps = ["Bzip2_jll", "TranscodingStreams"]
 git-tree-sha1 = "84990fa864b7f2b4901901ca12736e45ee79068c"
@@ -80,10 +74,10 @@ uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
 version = "1.3.0+1"
 
 [[deps.CuPDLPx]]
-deps = ["CUDA_Runtime_jll", "CUDA_SDK_jll", "MathOptInterface", "cuPDLPx_jll"]
+deps = ["MathOptInterface", "cuPDLPx_jll"]
 path = "."
 uuid = "bcd6524d-1420-4b17-a582-359cb8a71a63"
-version = "0.2.7"
+version = "0.2.8"
 
 [[deps.Dates]]
 deps = ["Printf"]
@@ -238,7 +232,7 @@ version = "1.49.0"
 
 [[deps.MozillaCACerts_jll]]
 uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
-version = "2025.5.20"
+version = "2025.11.4"
 
 [[deps.MutableArithmetics]]
 deps = ["LinearAlgebra", "SparseArrays", "Test"]
@@ -291,7 +285,7 @@ version = "2.8.3"
 [[deps.Pkg]]
 deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "Random", "SHA", "TOML", "Tar", "UUIDs", "p7zip_jll"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-version = "1.12.0"
+version = "1.12.1"
 
     [deps.Pkg.extensions]
     REPLExt = "REPL"
@@ -425,9 +419,9 @@ version = "1.3.1+2"
 
 [[deps.cuPDLPx_jll]]
 deps = ["Artifacts", "CUDA_Runtime_jll", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "TOML", "Zlib_jll"]
-git-tree-sha1 = "30dc3622db5c6d5a9997daa7c04a2588e75fa0c1"
+git-tree-sha1 = "753298766f9c1a85726f631afed0d8d991de7dcc"
 uuid = "bca5daad-f4d3-5101-ae12-8b63679c982c"
-version = "0.2.7+0"
+version = "0.2.8+0"
 
 [[deps.libblastrampoline_jll]]
 deps = ["Artifacts", "Libdl"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,25 +1,23 @@
 name = "CuPDLPx"
 uuid = "bcd6524d-1420-4b17-a582-359cb8a71a63"
-version = "0.2.7"
+version = "0.2.8"
 
 [deps]
-CUDA_Runtime_jll = "76a88914-d11a-5bdc-97e0-2f5a05c973a2"
-CUDA_SDK_jll = "6cbf2f2e-7e60-5632-ac76-dca2274e0be0"
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 cuPDLPx_jll = "bca5daad-f4d3-5101-ae12-8b63679c982c"
 
 [compat]
-CUDA_Runtime_jll = "0.19.2"
 CUDA_SDK_jll = "13.0.2"
 Clang = "0.19.0"
 MathOptInterface = "1.46.0"
-cuPDLPx_jll = "0.2.7"
+cuPDLPx_jll = "0.2.8"
 julia = "1.10"
 
 [extras]
+CUDA_SDK_jll = "6cbf2f2e-7e60-5632-ac76-dca2274e0be0"
 Clang = "40e3b903-d033-50b4-a0cc-940c62c95e31"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-gen = ["Clang"]
+gen = ["Clang", "CUDA_SDK_jll"]
 test = ["Test"]

--- a/gen/Project.toml
+++ b/gen/Project.toml
@@ -6,4 +6,4 @@ cuPDLPx_jll = "bca5daad-f4d3-5101-ae12-8b63679c982c"
 [compat]
 Clang = "0.19.0"
 CUDA_SDK_jll = "13.0.2"
-cuPDLPx_jll = "0.2.7"
+cuPDLPx_jll = "0.2.8"


### PR DESCRIPTION
## Fixes #20.

`CuPDLPx` pinned `CUDA_Runtime_jll = "0.19.2"` as a direct dep, but never uses it — the CUDA runtime comes transitively from the `cuPDLPx_jll` binary, which has no version bound. That pin blocked installing `CUDA@6` (needs `CUDA_Runtime_jll` 0.21–0.23).

  - Remove `CUDA_Runtime_jll` from deps/compat (still resolved transitively)
  - Move `CUDA_SDK_jll` to the `gen` target (codegen-only)
  - Bump `cuPDLPx_jll` compat and version to `0.2.8`
